### PR TITLE
DMA Channel Fix

### DIFF
--- a/uVGA.cpp
+++ b/uVGA.cpp
@@ -209,7 +209,27 @@ uVGA::uVGA(int dma_number, int sram_u_dma_number, int sram_u_dma_fix_number, int
 
 LED_INIT;
 LED_ON;
+	
 	// select pixel DMA to use
+	
+	if (dma_number==0 && sram_u_dma_number==0 && sram_u_dma_fix_number==0) {
+		//use Channelallocation from DMAChannel.h
+		dmachan1.begin(false);
+		dmachan2.begin(false);
+		dmachan3.begin(false);
+#ifdef DEBUG
+		Serial.print("uVGA allocated DMA Channels: ");
+		Serial.print(dmachan1.channel);
+		Serial.print(",");
+		Serial.print(dmachan2.channel);
+		Serial.print(",");
+		Serial.println(dmachan3.channel);
+#endif
+		dma_number = dmachan1.channel;		
+		sram_u_dma_number = dmachan2.channel;
+		sram_u_dma_fix_number = dmachan3.channel;		
+	}	
+	
 	if((dma_number < 0) || (dma_number > 15) || (dma_number == graphic_dma))		// DMAx cannot be the same as gfx dma
 		dma_number = 0;
 

--- a/uVGA.h
+++ b/uVGA.h
@@ -132,11 +132,11 @@ public:
 	// =========================================================
 	// video settings
 	// =========================================================
-	// Default: DMA0, DMA1, DMA2, HSYNC on FTM0_CH0 (uses FTM0_CH0, CH1, CH7)
+	// Default: HSYNC on FTM0_CH0 (uses FTM0_CH0, CH1, CH7)
 	//          VSYNC on pin 29 (teensy 3.5, 3.6), 10 (teensy 3.2)
 	//          gfx_dma = last dma channel available
 	// =========================================================
-	uVGA(int dma_number = 0, int sram_u_dma_number = 1, int sram_u_dma_fix_number = 2, int hsync_ftm_num = 0, int hsync_ftm_channel_num = 0, int x1_ftm_channel_num = 7,int vsync_pin = DEFAULT_VSYNC_PIN, int graphic_dma = DMA_NUM_CHANNELS - 1);
+	uVGA(int dma_number = 0, int sram_u_dma_number = 0, int sram_u_dma_fix_number = 0, int hsync_ftm_num = 0, int hsync_ftm_channel_num = 0, int x1_ftm_channel_num = 7,int vsync_pin = DEFAULT_VSYNC_PIN, int graphic_dma = DMA_NUM_CHANNELS - 1);
 
 	// display VGA image
 	uvga_error_t begin(uVGAmodeline *modeline = NULL);

--- a/uVGA.h
+++ b/uVGA.h
@@ -136,6 +136,7 @@ public:
 	//          VSYNC on pin 29 (teensy 3.5, 3.6), 10 (teensy 3.2)
 	//          gfx_dma = last dma channel available
 	// =========================================================
+	DMAChannel dmachan1, dmachan2, dmachan3;	
 	uVGA(int dma_number = 0, int sram_u_dma_number = 0, int sram_u_dma_fix_number = 0, int hsync_ftm_num = 0, int hsync_ftm_channel_num = 0, int x1_ftm_channel_num = 7,int vsync_pin = DEFAULT_VSYNC_PIN, int graphic_dma = DMA_NUM_CHANNELS - 1);
 
 	// display VGA image


### PR DESCRIPTION
Not sure if this is the best way - you might want to change variable names to your style.
It might be the best to remove the "fixed" Channel-numbers completely ?

The DMA library allocats the numbers automatically - which is best for compatibility with other libraries.

